### PR TITLE
fix pwm check

### DIFF
--- a/tborg/tborg.py
+++ b/tborg/tborg.py
@@ -526,7 +526,7 @@ class ThunderBorg(object):
             # Reverse
             command = rev
             pwm = -int(self._PWM_MAX * level)
-            pwm = self._PWM_MAX if pwm < -self._PWM_MAX else pwm
+            pwm = self._PWM_MAX if pwm > self._PWM_MAX else pwm
         else:
             # Forward / stopped
             command = fwd


### PR DESCRIPTION
The check should be the same as forward as pwm value is from 0 to 255.

For example, if level is -1.1, pwm value at line 528 will be 280.5 (due to a negative int casting)

on line 529, 280.5 is more than self._PWM_MAX and the value of 280.5 will be used, which will result in an error

